### PR TITLE
fix : 중복 조절 사이즈 수정

### DIFF
--- a/artijjaek-batch/src/main/kotlin/com/artijjaek/batch/job/CrawlingBatchConfig.kt
+++ b/artijjaek-batch/src/main/kotlin/com/artijjaek/batch/job/CrawlingBatchConfig.kt
@@ -64,7 +64,7 @@ class CrawlingBatchConfig(
             val crawledArticles = crawler.crawl(company)
 
             // Article 중복 제거
-            val existingUrls = articleDomainService.findByCompanyRecent(company, 10)
+            val existingUrls = articleDomainService.findByCompanyRecent(company, crawledArticles.size.toLong())
                 .map { it.link }
                 .toList()
             val newArticles = crawledArticles.filter { it.link !in existingUrls }


### PR DESCRIPTION
### **User description**
### :triangular_flag_on_post:이슈 번호
X

### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [X] 수정
- [ ] 기능 삭제
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- bugfix/infra -> develop

### :memo:변경 사항
- 10개 -> 크롤링된 사이즈 만큼으로 수정

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
X


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed duplicate article detection to use actual crawled size

- Changed hardcoded limit from 10 to dynamic crawled articles count

- Ensures deduplication logic matches actual data volume


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Crawl Articles"] --> B["Get Existing URLs"]
  B --> C["Fixed: Use crawledArticles.size"]
  C --> D["Filter Duplicates"]
  D --> E["New Articles"]
  style C fill:#90EE90
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CrawlingBatchConfig.kt</strong><dd><code>Replace hardcoded limit with dynamic crawled size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

artijjaek-batch/src/main/kotlin/com/artijjaek/batch/job/CrawlingBatchConfig.kt

<ul><li>Changed <code>findByCompanyRecent()</code> parameter from hardcoded <code>10</code> to <br><code>crawledArticles.size.toLong()</code><br> <li> Ensures duplicate detection uses the actual number of crawled articles<br> <li> Fixes potential issue where fewer than 10 articles were crawled but <br>still checked against 10 existing records</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/97/files#diff-f6b23371fa2f13464796a03650a622241a979b769841f59452e87d82f2f67189">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

