### PR TITLE
[#100] feat : 에러 공통 처리

### DIFF
--- a/artijjaek-api/src/main/kotlin/com/artijjaek/api/common/error/GlobalExceptionHandler.kt
+++ b/artijjaek-api/src/main/kotlin/com/artijjaek/api/common/error/GlobalExceptionHandler.kt
@@ -1,0 +1,113 @@
+package com.artijjaek.api.common.error
+
+import com.artijjaek.core.common.error.ApplicationException
+import com.artijjaek.core.common.error.ErrorCode
+import com.artijjaek.core.common.error.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    private val LOG_FORMAT = "Error: {}, Class : {}, Message : {}, Stack : {}"
+    private val LOG_CODE_FORMAT = "Error: {}, Code : {}, Message : {}, HttpStatus : {}, Stack : {}"
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    /**
+     * == Application Exception ==
+     *
+     * @return Each errorCode
+     * @throws ApplicationException
+     */
+    @ExceptionHandler(ApplicationException::class)
+    fun applicationException(exception: ApplicationException): ResponseEntity<ErrorResponse> {
+        log.error(
+            LOG_CODE_FORMAT,
+            "ApplicationException",
+            exception.code,
+            exception.message,
+            exception.httpStatus,
+            exception.stackTrace
+        )
+
+        val httpStatus: HttpStatus = HttpStatus.valueOf(exception.httpStatus)
+
+        return ResponseEntity
+            .status(httpStatus)
+            .body(ErrorResponse(code = exception.code, message = exception.message))
+    }
+
+    /**
+     * == 런타임 Exception ==
+     *
+     * @return INTERNAL_SERVER_ERROR
+     * @throws RuntimeException
+     */
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun runtimeException(exception: NoResourceFoundException): ResponseEntity<ErrorResponse> {
+        log.error(
+            LOG_FORMAT,
+            "NoResourceFoundException",
+            exception.javaClass.getSimpleName(),
+            exception.message,
+            exception.getStackTrace()
+        )
+
+        val errorCode = ErrorCode.API_NOT_FOUND_ERROR
+
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse(code = errorCode.code, errorCode.message))
+    }
+
+    /**
+     * == 런타임 Exception ==
+     *
+     * @return INTERNAL_SERVER_ERROR
+     * @throws RuntimeException
+     */
+    @ExceptionHandler(RuntimeException::class)
+    fun runtimeException(exception: RuntimeException): ResponseEntity<ErrorResponse> {
+        log.error(
+            LOG_FORMAT,
+            "RuntimeException",
+            exception.javaClass.getSimpleName(),
+            exception.message,
+            exception.getStackTrace()
+        )
+
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse(code = errorCode.code, errorCode.message))
+    }
+
+    /**
+     * == 기타 Exception ==
+     *
+     * @return INTERNAL_SERVER_ERROR
+     * @throws Exception
+     */
+    @ExceptionHandler(Exception::class)
+    fun handleException(exception: Exception): ResponseEntity<ErrorResponse> {
+        log.error(
+            LOG_FORMAT,
+            "Exception",
+            exception.javaClass.getSimpleName(),
+            exception.message,
+            exception.getStackTrace()
+        )
+
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse(code = errorCode.code, errorCode.message))
+    }
+
+}

--- a/artijjaek-api/src/main/kotlin/com/artijjaek/api/service/MemberService.kt
+++ b/artijjaek-api/src/main/kotlin/com/artijjaek/api/service/MemberService.kt
@@ -5,6 +5,8 @@ import com.artijjaek.api.dto.request.RegisterMemberRequest
 import com.artijjaek.api.dto.request.SubscriptionChangeRequest
 import com.artijjaek.api.dto.request.UnsubscriptionRequest
 import com.artijjaek.api.dto.response.MemberDataResponse
+import com.artijjaek.core.common.error.ApplicationException
+import com.artijjaek.core.common.error.ErrorCode.*
 import com.artijjaek.core.common.mail.service.MailService
 import com.artijjaek.core.domain.category.entity.Category
 import com.artijjaek.core.domain.category.service.CategoryDomainService
@@ -36,7 +38,7 @@ class MemberService(
     @Transactional
     fun register(request: RegisterMemberRequest) {
         memberDomainService.findByEmailAndMemberStatus(request.email, MemberStatus.ACTIVE)
-            ?.let { throw IllegalStateException("This email already exists.") }
+            ?.let { throw ApplicationException(MEMBER_DUPLICATE_ERROR) }
 
         val memberToken = UuidTokenGenerator.generatorUuidToken()
 
@@ -65,10 +67,10 @@ class MemberService(
     @Transactional(readOnly = true)
     fun getMemberDataWithToken(email: String, token: String): MemberDataResponse {
         val member = memberDomainService.findByEmailAndMemberStatus(email, MemberStatus.ACTIVE)
-            ?: throw IllegalStateException("Member Not Found.")
+            ?: throw ApplicationException(MEMBER_NOT_FOUND_ERROR)
 
         if (member.uuidToken != token) {
-            throw IllegalArgumentException("Token Not Matched")
+            throw ApplicationException(MEMBER_TOKEN_NOT_MATCH_ERROR)
         }
 
         val companyIds = companySubscriptionDomainService.findAllByMember(member)
@@ -82,10 +84,10 @@ class MemberService(
     @Transactional
     fun changeSubscription(request: SubscriptionChangeRequest) {
         val member = memberDomainService.findByEmailAndMemberStatus(request.email, MemberStatus.ACTIVE)
-            ?: throw IllegalStateException("Member Not Found.")
+            ?: throw ApplicationException(MEMBER_NOT_FOUND_ERROR)
 
         if (member.uuidToken != request.token) {
-            throw IllegalArgumentException("Token is not matched.")
+            throw ApplicationException(MEMBER_TOKEN_NOT_MATCH_ERROR)
         }
 
         // 구독 회사 변경
@@ -104,10 +106,10 @@ class MemberService(
     @Transactional
     fun cancelSubscription(request: UnsubscriptionRequest) {
         val member = memberDomainService.findByEmailAndMemberStatus(request.email, MemberStatus.ACTIVE)
-            ?: throw IllegalStateException("Member Not Found.")
+            ?: throw ApplicationException(MEMBER_NOT_FOUND_ERROR)
 
         if (member.uuidToken != request.token) {
-            throw IllegalArgumentException("Token is not matched.")
+            throw ApplicationException(MEMBER_TOKEN_NOT_MATCH_ERROR)
         }
 
         member.changeMemberStatus(MemberStatus.DELETED)

--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/ai/GeminiClient.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/ai/GeminiClient.kt
@@ -1,5 +1,7 @@
 package com.artijjaek.core.ai
 
+import com.artijjaek.core.common.error.ApplicationException
+import com.artijjaek.core.common.error.ErrorCode.CATEGORY_NOT_FOUND_ERROR
 import com.artijjaek.core.domain.article.entity.Article
 import com.artijjaek.core.domain.category.entity.Category
 import com.google.genai.Client
@@ -82,7 +84,7 @@ class GeminiClient(
             }
         }
 
-        throw IllegalStateException("카테고리를 찾을 수 없습니다.")
+        throw ApplicationException(CATEGORY_NOT_FOUND_ERROR)
     }
 
     private fun getCategoryString(categories: List<Category>): String {

--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ApplicationException.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ApplicationException.kt
@@ -1,0 +1,7 @@
+package com.artijjaek.core.common.error
+
+class ApplicationException(
+    val code: String, val httpStatus: Int, override val message: String
+) : RuntimeException(message) {
+    constructor(errorCode: ErrorCode) : this(errorCode.code, errorCode.httpStatus, errorCode.message)
+}

--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorCode.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorCode.kt
@@ -1,0 +1,29 @@
+package com.artijjaek.core.common.error
+
+import org.apache.http.HttpStatus
+import org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR
+import org.apache.http.HttpStatus.SC_NOT_FOUND
+
+enum class ErrorCode(val code: String, val httpStatus: Int, val message: String) {
+
+    // Article Error
+    // Category Error
+    CATEGORY_NOT_FOUND_ERROR("CAE-1", SC_NOT_FOUND, "존재하지 않는 카테고리입니다."),
+
+    // Company Error
+    // Inquiry Error
+    // Member Error
+    MEMBER_NOT_FOUND_ERROR("MEE-1", SC_NOT_FOUND, "존재하지 않는 사용자입니다."),
+    MEMBER_DUPLICATE_ERROR("MEE-2", HttpStatus.SC_BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    MEMBER_TOKEN_NOT_MATCH_ERROR("MEE-3", HttpStatus.SC_UNAUTHORIZED, "토큰이 일치하지 않습니다."),
+
+    // Subscription Error
+    // Unsubscription Error
+
+    // Request Error
+    API_NOT_FOUND_ERROR("REE-1", SC_NOT_FOUND, "존재하지 않는 API입니다."),
+
+    // Server Error
+    INTERNAL_SERVER_ERROR("SVE-1", SC_INTERNAL_SERVER_ERROR, "내부 서버 에러입니다.")
+
+}

--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorResponse.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.artijjaek.core.common.error
+
+data class ErrorResponse(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+) {
+    constructor(code: String, message: String) : this(false, code, message)
+}


### PR DESCRIPTION
### **User description**
### :triangular_flag_on_post:이슈 번호
- #100

### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 수정
- [ ] 기능 삭제
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/error-response -> develop

### :memo:변경 사항
- GlobalException handler 추가.
- ErrorResponse 추가.
- Error Code 추가.
- ApplicationException 추가.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
X


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement centralized error handling with GlobalExceptionHandler

- Create ApplicationException and ErrorCode enum for standardized errors

- Define ErrorResponse DTO for consistent API error responses

- Replace generic exceptions with ApplicationException across services


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Services<br/>MemberService<br/>GeminiClient"] -->|"throw"| B["ApplicationException"]
  B -->|"caught by"| C["GlobalExceptionHandler"]
  C -->|"uses"| D["ErrorCode Enum"]
  C -->|"returns"| E["ErrorResponse"]
  D -->|"defines"| F["HTTP Status<br/>Error Code<br/>Message"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GlobalExceptionHandler.kt</strong><dd><code>Global exception handler with centralized error management</code></dd></summary>
<hr>

artijjaek-api/src/main/kotlin/com/artijjaek/api/common/error/GlobalExceptionHandler.kt

<ul><li>New RestControllerAdvice class handling multiple exception types<br> <li> Handles ApplicationException with specific error codes and HTTP <br>statuses<br> <li> Handles NoResourceFoundException, RuntimeException, and generic <br>Exception<br> <li> Logs exceptions with detailed context information</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-0fec632492024ea621fde04fe9075638469f1edd19012ad99e35a29c92774f12">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApplicationException.kt</strong><dd><code>Custom application exception with error code support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ApplicationException.kt

<ul><li>New custom exception class extending RuntimeException<br> <li> Stores error code, HTTP status, and message<br> <li> Provides constructor overload accepting ErrorCode enum</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-36cb5a3c6870fdd437218377286b22dd24711e6f901e0e7dd2115f4904b0d560">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorCode.kt</strong><dd><code>Enumeration of application error codes and statuses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorCode.kt

<ul><li>Enum defining standardized error codes with HTTP statuses<br> <li> Includes member-related errors (duplicate, not found, token mismatch)<br> <li> Includes category and API not found errors<br> <li> Provides consistent error messaging in Korean</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-a0d257d1976bc2d90c8e37b9be53bcbe8c9fc13e4d2e394bbafb14f6f3c6db63">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorResponse.kt</strong><dd><code>Error response data transfer object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

artijjaek-core/src/main/kotlin/com/artijjaek/core/common/error/ErrorResponse.kt

<ul><li>Data class for standardized API error responses<br> <li> Contains success flag, error code, and message fields<br> <li> Provides convenience constructor with default success=false</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-e240dc29e38db6c0926d68c685739f229edec55b34efd1e7183de4cec372622e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MemberService.kt</strong><dd><code>Replace generic exceptions with ApplicationException</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

artijjaek-api/src/main/kotlin/com/artijjaek/api/service/MemberService.kt

<ul><li>Replace IllegalStateException with ApplicationException for member not <br>found<br> <li> Replace IllegalStateException with ApplicationException for duplicate <br>email<br> <li> Replace IllegalArgumentException with ApplicationException for token <br>mismatch<br> <li> Import ApplicationException and ErrorCode constants</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-17ba57ec765eb7beace4e9a7afb48be9367ce0a0a091b3e2012aa9f93284c3f1">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GeminiClient.kt</strong><dd><code>Replace exception with ApplicationException in AI client</code>&nbsp; </dd></summary>
<hr>

artijjaek-core/src/main/kotlin/com/artijjaek/core/ai/GeminiClient.kt

<ul><li>Replace IllegalStateException with ApplicationException for category <br>not found<br> <li> Import ApplicationException and CATEGORY_NOT_FOUND_ERROR</ul>


</details>


  </td>
  <td><a href="https://github.com/KJBig/artijjaek-backend/pull/103/files#diff-8ef26435dc0907ad746d7b02457451f80b2b435e59ff78add8e9460dcf3796ed">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

