### PR TITLE
Develop

### DIFF
--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/mail/service/MailService.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/common/mail/service/MailService.kt
@@ -157,9 +157,9 @@ class MailService(
 
             mimeMessageHelper.setText(content, true)
             javaMailSender.send(mimeMessage)
-            log.info("신규 아티클 메일 발송 성공!")
+            log.info("신규 아티클 메일 발송 성공! : ${memberData.email} ")
         } catch (e: Exception) {
-            log.error("신규 아티클 메일 발송 실패!", e)
+            log.error("신규 아티클 메일 발송 실패! ${memberData.email} == ", e)
             throw RuntimeException(e)
         }
     }

--- a/artijjaek-core/src/main/kotlin/com/artijjaek/core/config/AsyncConfig.kt
+++ b/artijjaek-core/src/main/kotlin/com/artijjaek/core/config/AsyncConfig.kt
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
+import java.util.concurrent.ThreadPoolExecutor
 
 @Configuration
 @EnableAsync
@@ -24,9 +25,10 @@ class AsyncConfig {
     @Bean(name = ["asyncEmailThreadPoolExecutor"])
     fun getEmailExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
-        executor.setCorePoolSize(30)
-        executor.setMaxPoolSize(60)
-        executor.setQueueCapacity(600)
+        executor.setCorePoolSize(2)
+        executor.setMaxPoolSize(4)
+        executor.setQueueCapacity(1000)
+        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
         executor.setThreadNamePrefix("Artijjaek-Email-Thread-")
         executor.initialize()
         return executor


### PR DESCRIPTION
### :triangular_flag_on_post:이슈 번호
X

### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [X] 수정
- [ ] 기능 삭제
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- develop -> main

### :memo:변경 사항
- 이메일 전송 스레드 풀 설정 조정
    - CorePoolSize -> 2
    - MaxPoolSize -> 4

### :heavy_plus_sign:추가 메모 (없다면 X)
- SMTP의 421률을 확인해야함.
- Retry 정책 반영 필요
- 현재 구글 SMTP는 24시간 500개 제한. 추후 Google WorkSpace, AWS SES, Resend 중 전환 고려

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="960" height="262" alt="스크린샷 2026-02-20 오후 3 16 23" src="https://github.com/user-attachments/assets/790a7096-e560-4e43-9423-98ffa54fb423" />
